### PR TITLE
Allow CloudFormation action in CodePipeline to push stack outputs to an optional output artifact

### DIFF
--- a/cumulus/policies/cloudformation.py
+++ b/cumulus/policies/cloudformation.py
@@ -36,9 +36,7 @@ def get_policy_cloudformation_general_access(policy_name):
                         awacs.aws.Action("lambda", "*"),
                         awacs.aws.Action("sqs", "*"),
                         awacs.aws.Action("events", "*"),
-                        awacs.ecr.GetDownloadUrlForLayer,
-                        awacs.ecr.BatchGetImage,
-                        awacs.ecr.BatchCheckLayerAvailability,
+                        awacs.aws.Action("ecr", "*"),
                         awacs.iam.PassRole,
                     ],
                     Resource=["*"]

--- a/cumulus/policies/codebuild.py
+++ b/cumulus/policies/codebuild.py
@@ -37,9 +37,7 @@ def get_policy_code_build_general_access(policy_name):
                         awacs.aws.Action("sqs", "*"),
                         awacs.aws.Action("events", "*"),
                         awacs.aws.Action("logs", "*"),
-                        awacs.ecr.GetDownloadUrlForLayer,
-                        awacs.ecr.BatchGetImage,
-                        awacs.ecr.BatchCheckLayerAvailability,
+                        awacs.aws.Action("ecr", "*"),
                         awacs.iam.PassRole,
                     ],
                     Resource=["*"]


### PR DESCRIPTION
I'm being lazy and combining two changes into one PR here.

1. Adding ECR permissions to the roles used for CloudFormation and CodeBuild
2. Adding ability to optionally specify an output artifact name in a CloudFormation action, which will cause the stack output values to be pushed into a JSON file that is output for successive pipeline actions to access.