### PR TITLE
Enable optional S3 bucket creation

### DIFF
--- a/cumulus/steps/dev_tools/__init__.py
+++ b/cumulus/steps/dev_tools/__init__.py
@@ -1,4 +1,4 @@
-META_PIPELINE_BUCKET_REF = 'dev_tools-bucket-Ref'
+META_PIPELINE_BUCKET_NAME = 'dev_tools-pipeline-bucket-name'
 
 # Use this to get a Ref object to gain access to the pipeline bucket
 META_PIPELINE_BUCKET_POLICY_REF = 'pipeline-bucket-access-policy-Ref'

--- a/cumulus/steps/dev_tools/code_build_action.py
+++ b/cumulus/steps/dev_tools/code_build_action.py
@@ -19,7 +19,7 @@ from troposphere import iam,\
 from cumulus.chain import step
 
 from cumulus.steps.dev_tools import META_PIPELINE_BUCKET_POLICY_REF, \
-    META_PIPELINE_BUCKET_REF
+    META_PIPELINE_BUCKET_NAME
 
 
 class CodeBuildAction(step.Step):
@@ -83,7 +83,7 @@ class CodeBuildAction(step.Step):
                 Type='LINUX_CONTAINER',
                 EnvironmentVariables=[
                     # TODO: allow these to be injectable, or just the whole environment?
-                    {'Name': 'PIPELINE_BUCKET', 'Value': chain_context.metadata[META_PIPELINE_BUCKET_REF]}
+                    {'Name': 'PIPELINE_BUCKET', 'Value': chain_context.metadata[META_PIPELINE_BUCKET_NAME]}
                 ],
             )
 

--- a/cumulus/steps/storage/s3bucket.py
+++ b/cumulus/steps/storage/s3bucket.py
@@ -1,0 +1,45 @@
+from troposphere.s3 import Bucket, VersioningConfiguration
+
+from cumulus.chain import step
+
+
+class S3Bucket(step.Step):
+    def __init__(self,
+                 logical_name,
+                 bucket_name,
+                 # bucket_policy_statements=None,
+                 ):
+        """
+
+        :type bucket_name: the name of the bucket that will be created suffixed with the chaincontext instance name
+        :type bucket_policy_statements: [awacs.aws.Statement]
+        """
+        step.Step.__init__(self)
+        self.logical_name = logical_name
+        self.bucket_name = bucket_name
+        # TODO: this property is a vistigial one from when this was ripped out of the pipeline,
+        # however, leaving it here as it is surely useful if you want to just create a bucket
+        # with some policies.
+        # self.bucket_policy_statements = bucket_policy_statements
+
+    def handle(self, chain_context):
+        """
+        This step adds in the shell of a pipeline.
+         * s3 bucket
+         * policies for the bucket and pipeline
+         * your next step in the chain MUST be a source stage
+        :param chain_context:
+        :return:
+        """
+
+        bucket = Bucket(
+            self.logical_name,
+            BucketName=self.bucket_name,
+            VersioningConfiguration=VersioningConfiguration(
+                Status="Enabled"
+            )
+        )
+
+        chain_context.template.add_resource(bucket)
+
+        print("Added bucket: " + self.logical_name)

--- a/tests/stacker_test/conf/acceptance.env
+++ b/tests/stacker_test/conf/acceptance.env
@@ -2,3 +2,8 @@
 # http://stacker.readthedocs.io/en/latest/environments.html
 namespace: acc
 env: ac
+VpcId: vpc-894b89ef
+BaseDomain: playpen.dsl.aws.shaw.ca
+PrivateSubnets: subnet-7b8cba32,subnet-ed041b8a
+SshKeyName: stc-admin-March-2017-PLAYPEN
+ALBCertName: ${ssmstore us-west-2@/simpleweb/bswift/ALBCertName}

--- a/tests/unit/steps/test_pipeline.py
+++ b/tests/unit/steps/test_pipeline.py
@@ -8,7 +8,7 @@
 import unittest
 
 import troposphere
-from troposphere import codepipeline, codebuild
+from troposphere import codepipeline, codebuild, s3
 
 from cumulus.chain import chaincontext
 from cumulus.steps.dev_tools import pipeline, code_build_action
@@ -56,6 +56,31 @@ class TestPipelineStep(unittest.TestCase):
 
         pipelines = TemplateQuery.get_resource_by_type(t, codepipeline.Pipeline)
         self.assertTrue(len(pipelines), 1)
+
+    def test_pipeline_creates_default_bucket(self):
+
+        sut = pipeline.Pipeline(
+            name='test',
+            bucket_name='testbucket',
+        )
+        sut.handle(self.context)
+        t = self.context.template
+
+        the_bucket = TemplateQuery.get_resource_by_type(t, s3.Bucket)
+        self.assertTrue(len(the_bucket), 1)
+
+    def test_pipeline_uses_non_default_bucket(self):
+        sut = pipeline.Pipeline(
+            name='test',
+            bucket_name='testbucket',
+            create_bucket=False,
+        )
+        sut.handle(self.context)
+        t = self.context.template
+
+        the_bucket = TemplateQuery.get_resource_by_type(t, s3.Bucket)
+        self.assertEqual(len(the_bucket), 0)
+
     #
     # def test_codebuild_should_add_stage(self):
     #


### PR DESCRIPTION
This enables pipelines to create their own, and gives more flexibility
to the release cycle when using tooling that doesn't clear out
s3 buckets for you.  Also allows you to use a bucket from another
account.

