### PR TITLE
Flake8 got more picky. Fix it

### DIFF
--- a/cumulus/chain/step.py
+++ b/cumulus/chain/step.py
@@ -11,4 +11,4 @@ class Step:
 
     def handle(self, chain_context):
         # type: (chaincontext.ChainContext) -> None
-        raise NotImplemented("handle must be implemented")
+        raise NotImplementedError("handle must be implemented")

--- a/cumulus/steps/dev_tools/code_build_action.py
+++ b/cumulus/steps/dev_tools/code_build_action.py
@@ -140,10 +140,10 @@ class CodeBuildAction(step.Step):
             )
             chain_context.template.add_resource(sg)
             vpc_config = {'VpcConfig': codebuild.VpcConfig(
-                    VpcId=self.vpc_config.vpc_id,
-                    Subnets=self.vpc_config.subnets,
-                    SecurityGroupIds=[Ref(sg)],
-                )}
+                VpcId=self.vpc_config.vpc_id,
+                Subnets=self.vpc_config.subnets,
+                SecurityGroupIds=[Ref(sg)],
+            )}
 
         project_name = "Project%s" % name
 

--- a/cumulus/types/codebuild/buildaction.py
+++ b/cumulus/types/codebuild/buildaction.py
@@ -9,11 +9,11 @@ class SourceS3Action(troposphere.codepipeline.Actions):
         super(SourceS3Action, self).__init__(**kwargs)
 
         self.ActionTypeId = troposphere.codepipeline.ActionTypeId(
-                Category="Source",
-                Owner="AWS",
-                Version="1",
-                Provider='S3',
-            )
+            Category="Source",
+            Owner="AWS",
+            Version="1",
+            Provider='S3',
+        )
         self.RunOrder = "1"
 
 
@@ -25,11 +25,11 @@ class SourceCodeCommitAction(troposphere.codepipeline.Actions):
         super(SourceCodeCommitAction, self).__init__(**kwargs)
 
         self.ActionTypeId = troposphere.codepipeline.ActionTypeId(
-                Category="Source",
-                Owner="AWS",
-                Version="1",
-                Provider="CodeCommit",
-            )
+            Category="Source",
+            Owner="AWS",
+            Version="1",
+            Provider="CodeCommit",
+        )
         self.RunOrder = "1"
 
 
@@ -41,11 +41,11 @@ class CodeBuildAction(troposphere.codepipeline.Actions):
         super(CodeBuildAction, self).__init__(**kwargs)
 
         self.ActionTypeId = troposphere.codepipeline.ActionTypeId(
-                Category="Build",
-                Owner="AWS",
-                Version="1",
-                Provider="CodeBuild"
-            )
+            Category="Build",
+            Owner="AWS",
+            Version="1",
+            Provider="CodeBuild"
+        )
         self.RunOrder = "1"
 
 
@@ -57,11 +57,11 @@ class LambdaAction(troposphere.codepipeline.Actions):
         super(LambdaAction, self).__init__(**kwargs)
 
         self.ActionTypeId = troposphere.codepipeline.ActionTypeId(
-                Category="Invoke",
-                Owner="AWS",
-                Version="1",
-                Provider='Lambda',
-            )
+            Category="Invoke",
+            Owner="AWS",
+            Version="1",
+            Provider='Lambda',
+        )
         self.RunOrder = "1"
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ replace = __version__ = '{new_version}'
 universal = 1
 
 [flake8]
+ignore = W605  # this is for components/userdata/windows.py
 exclude = docs
 max-line-length = 140
 

--- a/tests/stacker_test/blueprints/s3_bucket.py
+++ b/tests/stacker_test/blueprints/s3_bucket.py
@@ -13,6 +13,6 @@ class S3Simple(Blueprint):
         t = self.template
 
         t.add_resource(Bucket(
-           "S3Bucket",
-           BucketName='bswift-int-test-asdf'
+            "S3Bucket",
+            BucketName='bswift-int-test-asdf'
         ))


### PR DESCRIPTION
Flake 8 isn't locked to a version.    3.6 was just released. 

Fixed the new things it complains about.  Mostly indenting, and `cumulus/components/userdata/windows.py` escapes.. ugh. 