### PR TITLE
Support for injectable cloudformation roles

### DIFF
--- a/cumulus/policies/codebuild.py
+++ b/cumulus/policies/codebuild.py
@@ -31,6 +31,7 @@ def get_policy_code_build_general_access(policy_name):
                         awacs.aws.Action("apigateway", "*"),
                         awacs.aws.Action("cloudwatch", "*"),
                         awacs.aws.Action("cloudfront", "*"),
+                        awacs.aws.Action("codepipeline", "*"),
                         awacs.aws.Action("rds", "*"),
                         awacs.aws.Action("dynamodb", "*"),
                         awacs.aws.Action("lambda", "*"),

--- a/cumulus/steps/dev_tools/cloud_formation_action.py
+++ b/cumulus/steps/dev_tools/cloud_formation_action.py
@@ -25,6 +25,7 @@ class CloudFormationAction(step.Step):
                  output_artifact_name=None,
                  cfn_action_role_arn=None,
                  cfn_action_config_role_arn=None,
+                 cfn_param_overrides=None,
                  ):
         """
         :type cfn_action_config_role_arn: [troposphere.iam.Policy]
@@ -37,6 +38,7 @@ class CloudFormationAction(step.Step):
         :type action_mode: cumulus.types.cloudformation.action_mode.ActionMode The actual CloudFormation action to execute
         """
         step.Step.__init__(self)
+        self.cfn_param_overrides = cfn_param_overrides
         self.action_name = action_name
         self.input_artifact_names = input_artifact_names
         self.input_template_path = input_template_path
@@ -94,6 +96,9 @@ class CloudFormationAction(step.Step):
 
         if self.cfn_action_role_arn:
             cloud_formation_action.RoleArn = self.cfn_action_role_arn
+
+        if self.cfn_param_overrides:
+            cloud_formation_action.Configuration['ParameterOverrides'] = self.cfn_param_overrides
 
         stage = cumulus.util.template_query.TemplateQuery.get_pipeline_stage_by_name(
             template=chain_context.template,

--- a/cumulus/steps/dev_tools/lambda_action.py
+++ b/cumulus/steps/dev_tools/lambda_action.py
@@ -11,7 +11,7 @@ from troposphere import iam, \
 import cumulus.policies
 import cumulus.policies.codebuild
 import cumulus.types.codebuild.buildaction
-import cumulus.util.tropo
+import cumulus.util.template_query
 from cumulus.chain import step
 from cumulus.steps.dev_tools import META_PIPELINE_BUCKET_POLICY_REF
 
@@ -74,14 +74,15 @@ class LambdaAction(step.Step):
                 codepipeline.InputArtifacts(Name=self.input_artifact_name)
             ],
             Configuration={
-                'FunctionName': self.function_name
+                'FunctionName': self.function_name,
+                'UserParameters': self.user_parameters,
             },
             RunOrder="1"
         )
 
         chain_context.template.add_resource(lambda_role)
 
-        stage = cumulus.util.tropo.TemplateQuery.get_pipeline_stage_by_name(
+        stage = cumulus.util.template_query.TemplateQuery.get_pipeline_stage_by_name(
             template=chain_context.template,
             stage_name=self.stage_name_to_add,
         )

--- a/cumulus/steps/dev_tools/pipeline.py
+++ b/cumulus/steps/dev_tools/pipeline.py
@@ -1,28 +1,27 @@
 
 import awacs
-import troposphere
-
-import awacs.iam
 import awacs.aws
-import awacs.sts
-import awacs.s3
-import awacs.logs
+import awacs.awslambda
+import awacs.codecommit
 import awacs.ec2
 import awacs.iam
-import awacs.codecommit
-import awacs.awslambda
-
-from cumulus.chain import step
-import cumulus.steps.dev_tools
-
+import awacs.logs
+import awacs.s3
+import awacs.sts
+import awacs.kms
+import troposphere
 from troposphere import codepipeline, Ref, iam
 from troposphere.s3 import Bucket, VersioningConfiguration
+
+import cumulus.steps.dev_tools
+from cumulus.chain import step
 
 
 class Pipeline(step.Step):
     def __init__(self,
                  name,
                  bucket_name,
+                 pipeline_service_role_arn=None,
                  create_bucket=True,
                  pipeline_policies=None,
                  bucket_policy_statements=None,
@@ -30,6 +29,8 @@ class Pipeline(step.Step):
                  ):
         """
 
+        :type pipeline_service_role_arn: basestring Override the pipeline service role. If you pass this
+                                                     the pipeline_policies is not used.
         :type create_bucket: bool if False, will not create the bucket. Will attach policies either way.
         :type bucket_name: the name of the bucket that will be created suffixed with the chaincontext instance name
         :type bucket_policy_statements: [awacs.aws.Statement]
@@ -40,6 +41,7 @@ class Pipeline(step.Step):
         self.name = name
         self.bucket_name = bucket_name
         self.create_bucket = create_bucket
+        self.pipeline_service_role_arn = pipeline_service_role_arn
         self.bucket_policy_statements = bucket_policy_statements
         self.pipeline_policies = pipeline_policies or []
         self.bucket_kms_key_arn = bucket_kms_key_arn
@@ -53,10 +55,9 @@ class Pipeline(step.Step):
         :param chain_context:
         :return:
         """
-
         if self.create_bucket:
             pipeline_bucket = Bucket(
-                "PipelineBucket%s" % chain_context.instance_name,
+                "PipelineBucket%s" % self.name,
                 BucketName=self.bucket_name,
                 VersioningConfiguration=VersioningConfiguration(
                     Status="Enabled"
@@ -87,6 +88,47 @@ class Pipeline(step.Step):
         chain_context.metadata[cumulus.steps.dev_tools.META_PIPELINE_BUCKET_POLICY_REF] = Ref(
             pipeline_bucket_access_policy)
 
+        default_pipeline_role = self.get_default_pipeline_role()
+        pipeline_service_role_arn = self.pipeline_service_role_arn or troposphere.GetAtt(default_pipeline_role, "Arn")
+
+        generic_pipeline = codepipeline.Pipeline(
+            "Pipeline",
+            RoleArn=pipeline_service_role_arn,
+            Stages=[],
+            ArtifactStore=codepipeline.ArtifactStore(
+                Type="S3",
+                Location=self.bucket_name,
+            )
+        )
+
+        if self.bucket_kms_key_arn:
+            encryption_config = codepipeline.EncryptionKey(
+                "ArtifactBucketKmsKey",
+                Id=self.bucket_kms_key_arn,
+                Type='KMS',
+            )
+            generic_pipeline.ArtifactStore.EncryptionKey = encryption_config
+
+        pipeline_output = troposphere.Output(
+            "PipelineName",
+            Description="Code Pipeline",
+            Value=Ref(generic_pipeline),
+        )
+        pipeline_bucket_output = troposphere.Output(
+            "PipelineBucket",
+            Description="Name of the input artifact bucket for the pipeline",
+            Value=self.bucket_name,
+        )
+
+        if not self.pipeline_service_role_arn:
+            chain_context.template.add_resource(default_pipeline_role)
+
+        chain_context.template.add_resource(pipeline_bucket_access_policy)
+        chain_context.template.add_resource(generic_pipeline)
+        chain_context.template.add_output(pipeline_output)
+        chain_context.template.add_output(pipeline_bucket_output)
+
+    def get_default_pipeline_role(self):
         # TODO: this can be cleaned up by using a policytype and passing in the pipeline role it should add itself to.
         pipeline_policy = iam.Policy(
             PolicyName="%sPolicy" % self.name,
@@ -148,7 +190,7 @@ class Pipeline(step.Step):
                             awacs.aws.Action("lambda", "*")
                         ],
                         Resource=["*"]
-                    )
+                    ),
                 ],
             )
         )
@@ -169,42 +211,7 @@ class Pipeline(step.Step):
             ),
             Policies=[pipeline_policy] + self.pipeline_policies
         )
-
-        generic_pipeline = codepipeline.Pipeline(
-            "Pipeline",
-            RoleArn=troposphere.GetAtt(pipeline_service_role, "Arn"),
-            Stages=[],
-            ArtifactStore=codepipeline.ArtifactStore(
-                Type="S3",
-                Location=self.bucket_name,
-            )
-            # TODO: optionally add kms key here
-        )
-
-        if self.bucket_kms_key_arn:
-            encryption_config = codepipeline.EncryptionKey(
-                "ArtifactBucketKmsKey",
-                Id=self.bucket_kms_key_arn,
-                Type='KMS',
-            )
-            generic_pipeline.ArtifactStore.EncryptionKey = encryption_config
-
-        pipeline_output = troposphere.Output(
-            "PipelineName",
-            Description="Code Pipeline",
-            Value=Ref(generic_pipeline),
-        )
-        pipeline_bucket_output = troposphere.Output(
-            "PipelineBucket",
-            Description="Name of the input artifact bucket for the pipeline",
-            Value=self.bucket_name,
-        )
-
-        chain_context.template.add_resource(pipeline_bucket_access_policy)
-        chain_context.template.add_resource(pipeline_service_role)
-        chain_context.template.add_resource(generic_pipeline)
-        chain_context.template.add_output(pipeline_output)
-        chain_context.template.add_output(pipeline_bucket_output)
+        return pipeline_service_role
 
     def get_default_bucket_policy_statements(self, pipeline_bucket):
         bucket_policy_statements = [

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ requirements = [
     'troposphere',
     'awacs',
     'termcolor',
+    'enum34',
 ]
 
 setup_requirements = ['pytest-runner', ]
@@ -28,7 +29,7 @@ test_requirements = [
     'pytest-cov',
     'coveralls',
     'awscli',
-    'mock'
+    'mock',
 ]
 
 extras = {

--- a/tests/stacker_test/run-integration.sh
+++ b/tests/stacker_test/run-integration.sh
@@ -34,6 +34,8 @@ set +e # turn off error mode, ie don't exit with a failure, let the loop continu
 end=$((SECONDS+600))
 pipeline_result=1
 while [ $SECONDS -lt ${end} ]; do
+#    uncomment to nuke without waiting. Do not check in the break uncommented.
+#    break;
     sleep 15
     # Get status from each stage in the pipeline
     pipeline_state=$(aws codepipeline get-pipeline-state --name ${PIPELINE_NAME} | jq -r '.stageStates[] | "\(.stageName) \(.latestExecution.status)"')

--- a/tests/unit/steps/dev_tools/test_code_build_action.py
+++ b/tests/unit/steps/dev_tools/test_code_build_action.py
@@ -1,0 +1,48 @@
+try:
+    # python 3
+    from unittest.mock import patch # noqa
+    from unittest.mock import MagicMock
+except:  # noqa
+    # python 2
+    from mock import patch, MagicMock # noqa
+
+import unittest
+
+import troposphere
+from troposphere import codepipeline  # noqa
+
+from cumulus.chain import chaincontext
+from cumulus.steps.dev_tools import META_PIPELINE_BUCKET_POLICY_REF, META_PIPELINE_BUCKET_NAME
+
+
+class TestCodeBuildAction(unittest.TestCase):
+
+    def setUp(self):
+        self.context = chaincontext.ChainContext(
+            template=troposphere.Template(),
+            instance_name='justtestin'
+        )
+        self.context.metadata[META_PIPELINE_BUCKET_POLICY_REF] = "blah"
+        self.context.metadata[META_PIPELINE_BUCKET_NAME] = troposphere.Ref("notabucket")
+
+        self.pipeline_name = "ThatPipeline"
+        self.deploy_stage_name = "DeployIt"
+        self.source_stage_name = "SourceIt"
+
+        TestCodeBuildAction._add_pipeline_and_stage_to_template(self.context.template, self.pipeline_name, self.deploy_stage_name)
+
+    def tearDown(self):
+        del self.context
+
+    @staticmethod
+    def _add_pipeline_and_stage_to_template(template, pipeline_name, deploy_stage_name):
+        pipeline = template.add_resource(troposphere.codepipeline.Pipeline(
+            pipeline_name,
+            Stages=[]
+        ))
+
+        deploy_stage = template.add_resource(troposphere.codepipeline.Stages(
+            Name=deploy_stage_name,
+            Actions=[]
+        ))
+        pipeline.properties['Stages'].append(deploy_stage)

--- a/tests/unit/steps/test_pipeline.py
+++ b/tests/unit/steps/test_pipeline.py
@@ -49,7 +49,8 @@ class TestPipelineStep(unittest.TestCase):
     def test_pipeline_has_two_stages(self):
 
         sut = pipeline.Pipeline(
-            name='test', bucket_name='testbucket'
+            name='test',
+            bucket_name='testbucket',
         )
         sut.handle(self.context)
         t = self.context.template
@@ -72,7 +73,7 @@ class TestPipelineStep(unittest.TestCase):
     def test_pipeline_uses_non_default_bucket(self):
         sut = pipeline.Pipeline(
             name='test',
-            bucket_name='testbucket',
+            bucket_name='ahhjustbucket',
             create_bucket=False,
         )
         sut.handle(self.context)
@@ -107,7 +108,7 @@ class TestPipelineStep(unittest.TestCase):
 
         project = action.create_project(
             chain_context=self.context,
-            codebuild_role='dummy-role',
+            codebuild_role_arn='dummy-role',
             codebuild_environment=self.environment,
             name='test',
         )
@@ -130,7 +131,7 @@ class TestPipelineStep(unittest.TestCase):
 
         project = action.create_project(
             chain_context=self.context,
-            codebuild_role='dummy-role',
+            codebuild_role_arn='dummy-role',
             codebuild_environment=self.environment,
             name='test',
         )


### PR DESCRIPTION
This cross account activity hit a lot of areas.  This PR is an accumulation of each area that had to be tweaked to get this to work. 

It's big and klunky.  Typically I would like to have these broken down into atomic pieces with context on each one.  Two PR's were made to precede this one however we're now left with this.  Hopefully it's not too arduous to get through. 

Beyond support for injectable cloudformation roles the following was added: 

Add validation check for pipeline when code build is added out of order
Give codebuild access to codepipeline
Add missing package
Add user parameters to lambda pipeline step

and more! 



