### PR TITLE
Fix lambda user params to truly be optional

### DIFF
--- a/cumulus/steps/dev_tools/lambda_action.py
+++ b/cumulus/steps/dev_tools/lambda_action.py
@@ -75,10 +75,12 @@ class LambdaAction(step.Step):
             ],
             Configuration={
                 'FunctionName': self.function_name,
-                'UserParameters': self.user_parameters,
             },
             RunOrder="1"
         )
+
+        if self.user_parameters:
+            lambda_action.Configuration['UserParameters'] = self.user_parameters
 
         chain_context.template.add_resource(lambda_role)
 


### PR DESCRIPTION
Before you were forced to send UserParameters to the lambda, or get a null ref exception. 

Lets not do that. 