### PR TITLE
Enable unique CodeBuild project names, by injecting stack namespace/p…

### DIFF
--- a/cumulus/steps/dev_tools/cloud_formation_action.py
+++ b/cumulus/steps/dev_tools/cloud_formation_action.py
@@ -116,8 +116,8 @@ class CloudFormationAction(step.Step):
         :param chain_context: chaincontext.ChainContext
         :type step_policies: [troposphere.iam.Policy]
         """
-        policy_name = "CloudFormationPolicy%stage" % chain_context.instance_name
-        role_name = "CloudFormationRole%stage" % self.action_name
+        policy_name = "CloudFormationPolicy%sStage" % chain_context.instance_name
+        role_name = "CloudFormationRole%sStage" % self.action_name
 
         all_policies = [
             cumulus.policies.cloudformation.get_policy_cloudformation_general_access(policy_name)

--- a/tests/stacker_test/blueprints/pipeline_simple.py
+++ b/tests/stacker_test/blueprints/pipeline_simple.py
@@ -96,6 +96,7 @@ phases:
 
         deploy_test = code_build_action.CodeBuildAction(
             prefix="test",
+            stack_namespace="MyPipeline",
             action_name="DeployMyStuff",
             stage_name_to_add=deploy_stage_name,
             input_artifact_name=service_artifact,
@@ -137,6 +138,7 @@ phases:
 
         the_chain.add(code_build_action.CodeBuildAction(
             prefix="test",
+            stack_namespace=troposphere.Ref("StackNameParam"),
             action_name="DestroyService",
             stage_name_to_add=destroy_stage_name,
             input_artifact_name=service_artifact,

--- a/tests/unit/steps/test_pipeline.py
+++ b/tests/unit/steps/test_pipeline.py
@@ -105,6 +105,7 @@ class TestPipelineStep(unittest.TestCase):
             action_name="Test",
             stage_name_to_add="the_stage",
             input_artifact_name="no-input",
+            stack_namespace="unique-codebuild-project",
         )
 
         project = action.create_project(
@@ -129,7 +130,8 @@ class TestPipelineStep(unittest.TestCase):
             ),
             action_name="testAction",
             stage_name_to_add="thestage",
-            input_artifact_name="test-input"
+            input_artifact_name="test-input",
+            stack_namespace="unique-codebuild-project",
         )
 
         project = action.create_project(


### PR DESCRIPTION
* Added a parameter `stack_namespace` for CodeBuildAction, allowing either a plain text or CFN parameter reference to be passed in, specifying the stack namespace. Use this as a prefix when generating the CodeBuild project's name, rather than extracting it from the deprecated `chain_context.instance_name`.
* Corrected a minor typo in the role/policy naming for CloudFormation (soothing my OCD)

