### PR TITLE
fixes naming issues with the EC2 and SecurityGroup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 install:
 - pip install -e .
 - pip install .[test]
+- pip freeze
 script:
 - py.test -s tests/unit --color=yes -v
 - flake8 cumulus tests

--- a/cumulus/steps/ec2/launch_config.py
+++ b/cumulus/steps/ec2/launch_config.py
@@ -46,7 +46,6 @@ class LaunchConfig(step.Step):
 
         launch_config_security_group = ec2.SecurityGroup(
             sg_name,
-            GroupName=sg_name,
             GroupDescription=sg_name,
             **self._get_security_group_parameters(sg_name)
         )

--- a/cumulus/steps/ec2/scaling_group.py
+++ b/cumulus/steps/ec2/scaling_group.py
@@ -12,12 +12,13 @@ class ScalingGroup(step.Step):
 
     def __init__(self,
                  use_update_policy=True,
+                 name='ScalingGroup'
                  ):
-        """
-        :type launch_type: LaunchType: the type of the ec2 that will be created
-        """
+
+        self.name = name
+
         step.Step.__init__(self,
-                           name='ScalingGroup')
+                           name=self.name)
 
         # Set default resource names for those not injected
         self.use_update_policy = use_update_policy

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ test_requirements = [
     'stacker',
     'flake8',
     'pytest-watch',
-    'pytest-cov',
     'coveralls',
     'awscli',
     'mock',


### PR DESCRIPTION
This change fixes some issues around the naming of security groups and instances created from auto scaling groups.